### PR TITLE
Runner set deployment

### DIFF
--- a/arc-controller/Chart.lock
+++ b/arc-controller/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gha-runner-scale-set-controller
+  repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+  version: 0.10.1
+digest: sha256:c5989e62e5deb12b3dd3d9548959694019d69dbf25a63b6eaae58d5e7c373770
+generated: "2025-05-16T14:26:28.2020484+08:00"

--- a/arc-controller/Chart.yaml
+++ b/arc-controller/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: arc
+version: 0.10.1
+dependencies:
+  - name: gha-runner-scale-set-controller
+    version: 0.10.1
+    repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+
+

--- a/arc-controller/values.yaml
+++ b/arc-controller/values.yaml
@@ -1,0 +1,144 @@
+# Default values for gha-runner-scale-set-controller.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+labels: {}
+
+# leaderElection will be enabled when replicaCount>1,
+# So, only one replica will in charge of reconciliation at a given time
+# leaderElectionId will be set to {{ define gha-runner-scale-set-controller.fullname }}.
+replicaCount: 1
+
+image:
+  repository: "ghcr.nju.edu.cn/actions/gha-runner-scale-set-controller"
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+env:
+## Define environment variables for the controller pod
+#  - name: "ENV_VAR_NAME_1"
+#    value: "ENV_VAR_VALUE_1"
+#  - name: "ENV_VAR_NAME_2"
+#    valueFrom:
+#      secretKeyRef:
+#        key: ENV_VAR_NAME_2
+#        name: secret-name
+#        optional: true
+
+serviceAccount:
+  # Specifies whether a service account should be created for running the controller pod
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  # You can not use the default service account for this.
+  name: ""
+
+podAnnotations: {}
+
+podLabels: {}
+
+podSecurityContext: {}
+# fsGroup: 2000
+
+securityContext: {}
+# capabilities:
+#   drop:
+#   - ALL
+# readOnlyRootFilesystem: true
+# runAsNonRoot: true
+# runAsUser: 1000
+
+resources: {}
+## We usually recommend not to specify default resources and to leave this as a conscious
+## choice for the user. This also increases chances charts run on environments with little
+## resources, such as Minikube. If you do want to specify resources, uncomment the following
+## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+# limits:
+#   cpu: 100m
+#   memory: 128Mi
+# requests:
+#   cpu: 100m
+#   memory: 128Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+topologySpreadConstraints: []
+
+# Mount volumes in the container.
+volumes: []
+volumeMounts: []
+
+# Leverage a PriorityClass to ensure your pods survive resource shortages
+# ref: https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+# PriorityClass: system-cluster-critical
+priorityClassName: ""
+
+## If `metrics:` object is not provided, or commented out, the following flags
+## will be applied the controller-manager and listener pods with empty values:
+## `--metrics-addr`, `--listener-metrics-addr`, `--listener-metrics-endpoint`.
+## This will disable metrics.
+##
+## To enable metrics, uncomment the following lines.
+metrics:
+  controllerManagerAddr: ":8080"
+  listenerAddr: ":8080"
+  listenerEndpoint: "/metrics"
+
+flags:
+  ## Log level can be set here with one of the following values: "debug", "info", "warn", "error".
+  ## Defaults to "debug".
+  logLevel: "debug"
+  ## Log format can be set with one of the following values: "text", "json"
+  ## Defaults to "text"
+  logFormat: "text"
+
+  ## Restricts the controller to only watch resources in the desired namespace.
+  ## Defaults to watch all namespaces when unset.
+  # watchSingleNamespace: ""
+
+  ## The maximum number of concurrent reconciles which can be run by the EphemeralRunner controller.
+  # Increase this value to improve the throughput of the controller.
+  # It may also increase the load on the API server and the external service (e.g. GitHub API).
+  runnerMaxConcurrentReconciles: 2
+
+  ## Defines how the controller should handle upgrades while having running jobs.
+  ##
+  ## The strategies available are:
+  ## - "immediate": (default) The controller will immediately apply the change causing the
+  ##   recreation of the listener and ephemeral runner set. This can lead to an
+  ##   overprovisioning of runners, if there are pending / running jobs. This should not
+  ##   be a problem at a small scale, but it could lead to a significant increase of
+  ##   resources if you have a lot of jobs running concurrently.
+  ##
+  ## - "eventual": The controller will remove the listener and ephemeral runner set
+  ##   immediately, but will not recreate them (to apply changes) until all
+  ##   pending / running jobs have completed.
+  ##   This can lead to a longer time to apply the change but it will ensure
+  ##   that you don't have any overprovisioning of runners.
+  updateStrategy: "immediate"
+
+  ## Defines a list of prefixes that should not be propagated to internal resources.
+  ## This is useful when you have labels that are used for internal purposes and should not be propagated to internal resources.
+  ## See https://github.com/actions/actions-runner-controller/issues/3533 for more information.
+  ##
+  ## By default, all labels are propagated to internal resources
+  ## Labels that match prefix specified in the list are excluded from propagation.
+  # excludeLabelPropagationPrefixes:
+  #   - "argocd.argoproj.io/instance"
+
+# Overrides the default `.Release.Namespace` for all resources in this chart.
+namespaceOverride: ""
+
+## Defines the K8s client rate limiter parameters.
+  # k8sClientRateLimiterQPS: 20
+  # k8sClientRateLimiterBurst: 30

--- a/nv-action/vllm-benchmarks/config/container-job-pod-template-npu-1-configmap.yaml
+++ b/nv-action/vllm-benchmarks/config/container-job-pod-template-npu-1-configmap.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pod-template-npu-1
+  namespace: nv-action
+data:
+  default.yaml: |
+    ---
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      annotations:
+        annotated-by: "extension"
+      labels:
+        labeled-by: "extension"
+    spec:
+      containers:
+        - name: $job
+          resources:
+            limits:
+              cpu: "23"
+              huawei.com/ascend-1980: "1"
+              memory: 64Gi
+            requests:
+              cpu: "23"
+              huawei.com/ascend-1980: "1"
+              memory: 32Gi
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /root/.cache
+            - name: driver-tools
+              mountPath: /usr/local/Ascend/driver/tools
+              readOnly: true
+            - name: check-npu
+              mountPath: /check-npu
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    # 配置github代理
+                    cat <<EOF >> /root/.gitconfig
+                    [url "https://gh-proxy.test.osinfra.cn/https://github.com/"]
+                        insteadOf = https://github.com/
+                    EOF
+      volumes:
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: nv-action-vllm-benchmarks-v2
+        - name: check-npu
+          configMap:
+            name: check-npu
+        - name: driver-tools
+          hostPath:
+            path: /usr/local/Ascend/driver/tools
+

--- a/nv-action/vllm-benchmarks/config/container-job-pod-template-npu-2-configmap.yaml
+++ b/nv-action/vllm-benchmarks/config/container-job-pod-template-npu-2-configmap.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pod-template-npu-2
+  namespace: nv-action
+data:
+  default.yaml: |
+    ---
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      annotations:
+        annotated-by: "extension"
+      labels:
+        labeled-by: "extension"
+    spec:
+      containers:
+        - name: $job
+          resources:
+            limits:
+              cpu: "46"
+              huawei.com/ascend-1980: "2"
+              memory: 128Gi
+            requests:
+              cpu: "46"
+              huawei.com/ascend-1980: "2"
+              memory: 64Gi
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /root/.cache
+            - name: driver-tools
+              mountPath: /usr/local/Ascend/driver/tools
+              readOnly: true
+            - name: check-npu
+              mountPath: /check-npu
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    # 配置github代理
+                    cat <<EOF >> /root/.gitconfig
+                    [url "https://gh-proxy.test.osinfra.cn/https://github.com/"]
+                        insteadOf = https://github.com/
+                    EOF
+      volumes:
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: nv-action-vllm-benchmarks-v2
+        - name: check-npu
+          configMap:
+            name: check-npu
+        - name: driver-tools
+          hostPath:
+            path: /usr/local/Ascend/driver/tools

--- a/nv-action/vllm-benchmarks/config/container-job-pod-template-npu-4-configmap.yaml
+++ b/nv-action/vllm-benchmarks/config/container-job-pod-template-npu-4-configmap.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pod-template-npu-4
+  namespace: nv-action
+data:
+  default.yaml: |
+    ---
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      annotations:
+        annotated-by: "extension"
+      labels:
+        labeled-by: "extension"
+    spec:
+      containers:
+        - name: $job
+          resources:
+            limits:
+              cpu: "92"
+              huawei.com/ascend-1980: "4"
+              memory: 256Gi
+            requests:
+              cpu: "92"
+              huawei.com/ascend-1980: "4"
+              memory: 128Gi
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /root/.cache
+            - name: driver-tools
+              mountPath: /usr/local/Ascend/driver/tools
+              readOnly: true
+            - name: check-npu
+              mountPath: /check-npu
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    # 配置github代理
+                    cat <<EOF >> /root/.gitconfig
+                    [url "https://gh-proxy.test.osinfra.cn/https://github.com/"]
+                        insteadOf = https://github.com/
+                    EOF
+      volumes:
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: nv-action-vllm-benchmarks-v2
+        - name: check-npu
+          configMap:
+            name: check-npu
+        - name: driver-tools
+          hostPath:
+            path: /usr/local/Ascend/driver/tools
+

--- a/nv-action/vllm-benchmarks/config/container-job-pod-template-npu-8-configmap.yaml
+++ b/nv-action/vllm-benchmarks/config/container-job-pod-template-npu-8-configmap.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pod-template-npu-8
+  namespace: nv-action
+data:
+  default.yaml: |
+    ---
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      annotations:
+        annotated-by: "extension"
+      labels:
+        labeled-by: "extension"
+    spec:
+      containers:
+        - name: $job
+          resources:
+            limits:
+              cpu: "184"
+              huawei.com/ascend-1980: "8"
+              memory: 512Gi
+            requests:
+              cpu: "184"
+              huawei.com/ascend-1980: "8"
+              memory: 256Gi
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /root/.cache
+            - name: driver-tools
+              mountPath: /usr/local/Ascend/driver/tools
+              readOnly: true
+            - name: check-npu
+              mountPath: /check-npu
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    # 配置github代理
+                    cat <<EOF >> /root/.gitconfig
+                    [url "https://gh-proxy.test.osinfra.cn/https://github.com/"]
+                        insteadOf = https://github.com/
+                    EOF
+      volumes:
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: nv-action-vllm-benchmarks-v2
+        - name: check-npu
+          configMap:
+            name: check-npu
+        - name: driver-tools
+          hostPath:
+            path: /usr/local/Ascend/driver/tools
+

--- a/nv-action/vllm-benchmarks/config/custom-runner-container-hook-pvc.yaml
+++ b/nv-action/vllm-benchmarks/config/custom-runner-container-hook-pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    everest.io/path: /custom-index
+    everest.io/reclaim-policy: retain-volume-only
+    everest.io/sfsturbo-share-id: 39a33a00-3be8-4345-8079-63cf23a44a88
+    everest.io/volume-as: absolute-path变
+    pvc-can-cleanup: 'true'
+  name: custom-index
+  namespace: nv-action
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Mi
+  storageClassName: csi-sfsturbo

--- a/nv-action/vllm-benchmarks/config/kustomization.yaml
+++ b/nv-action/vllm-benchmarks/config/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- namespace.yaml
+- custom-runner-container-hook-pvc.yaml
+- local-storage-pvc.yaml
+- pre-execute-script-check-npu-configmap.yaml
+- runner-pod-permission.yaml
+- container-job-pod-template-npu-1-configmap.yaml
+- container-job-pod-template-npu-2-configmap.yaml
+- container-job-pod-template-npu-4-configmap.yaml
+- container-job-pod-template-npu-8-configmap.yaml
+namespace: nv-action
+apiVersion: kustomize.config.k8s.io/v1beta1
+commonAnnotations:
+  kubernetes.ops.cluster: shanghai-icsl-cluster
+  kubernetes.ops.email: ""
+  kubernetes.ops.os.base: debian
+  kubernetes.ops.region: shanghai
+kind: Kustomization
+

--- a/nv-action/vllm-benchmarks/config/local-storage-pvc.yaml
+++ b/nv-action/vllm-benchmarks/config/local-storage-pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    everest.io/path: /ascend-ci-share-nv-action-vllm-benchmarks
+    everest.io/reclaim-policy: retain-volume-only
+    everest.io/sfsturbo-share-id: 23021270-7ebf-43b2-925c-b1686da4868a
+    everest.io/volume-as: absolute-path
+    pvc-can-cleanup: 'true'
+  name: nv-action-vllm-benchmarks-v2
+  namespace: nv-action
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 1200Gi
+  storageClassName: csi-sfsturbo

--- a/nv-action/vllm-benchmarks/config/namespace.yaml
+++ b/nv-action/vllm-benchmarks/config/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app: nv-action
+  name: nv-action

--- a/nv-action/vllm-benchmarks/config/pre-execute-script-check-npu-configmap.yaml
+++ b/nv-action/vllm-benchmarks/config/pre-execute-script-check-npu-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: check-npu
+  namespace: nv-action
+data:
+  check.sh: |
+    #!/bin/bash
+    if [ -c "/dev/davinci_manager" ]; then
+        while true; do
+            if npu-smi info &> /dev/null ; then
+                break
+            fi
+        done
+    fi

--- a/nv-action/vllm-benchmarks/config/runner-pod-permission.yaml
+++ b/nv-action/vllm-benchmarks/config/runner-pod-permission.yaml
@@ -1,0 +1,48 @@
+---
+# Source: gha-runner-scale-set/templates/kube_mode_serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: runner-service-account
+  namespace: nv-action
+
+---
+# Source: gha-runner-scale-set/templates/kube_mode_role.yaml
+# default permission for runner pod service account in kubernetes mode (container hook)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: runner-role
+  namespace: nv-action
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get", "create"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create", "delete"]
+---
+# Source: gha-runner-scale-set/templates/kube_mode_role_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: runner-rolebinding
+  namespace: nv-action
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: runner-role
+subjects:
+  - kind: ServiceAccount
+    name: runner-service-account
+    namespace: nv-action
+---

--- a/nv-action/vllm-benchmarks/linux-arm64-npu-1/Chart.lock
+++ b/nv-action/vllm-benchmarks/linux-arm64-npu-1/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gha-runner-scale-set
+  repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+  version: 0.10.1
+digest: sha256:6b60dc58ccdc6cb8c773464a60ace403fa54c6f235a40999f9e290671ccc3b2b
+generated: "2025-05-16T11:51:08.915957736+08:00"

--- a/nv-action/vllm-benchmarks/linux-arm64-npu-1/Chart.yaml
+++ b/nv-action/vllm-benchmarks/linux-arm64-npu-1/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: linux-arm64-npu-1
+version: 0.10.1
+dependencies:
+  - name: gha-runner-scale-set
+    version: 0.10.1
+    repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+
+

--- a/nv-action/vllm-benchmarks/linux-arm64-npu-1/values.yaml
+++ b/nv-action/vllm-benchmarks/linux-arm64-npu-1/values.yaml
@@ -1,0 +1,77 @@
+githubConfigUrl: https://github.com/nv-action/vllm-benchmarks
+
+githubConfigSecret: nv-action-vllm-benchmarks-secret
+
+template:
+  spec:
+    serviceAccountName: runner-service-account
+    initContainers:
+      - name: copy-origin-file
+        image: ghcr.io/actions/actions-runner:latest
+        command: ["sh", "-c", "cp -a /home/runner/k8s/. /app-data/  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: app-data
+          mountPath: /app-data
+      - name: copy-pvc-file
+        image: busybox
+        command: ["sh", "-c", "cp -f /shared-data/index.js /app-data/index.js  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: custom-index
+          mountPath: /shared-data  # PVC挂载路径
+        - name: app-data
+          mountPath: /app-data
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: ACTIONS_RUNNER_CONTAINER_HOOKS
+            value: /home/runner/k8s/index.js
+          - name: ACTIONS_RUNNER_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+            value: "false"
+          - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
+            value: /home/runner/pod-templates/default.yaml
+          - name: ACTIONS_RUNNER_USE_KUBE_SCHEDULER
+            value: "true"
+          - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+            value: "3600"
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: pod-templates
+            mountPath: /home/runner/pod-templates
+            readOnly: true
+          - name: shared-volume
+            mountPath: /root/.cache
+          - name: app-data
+            mountPath: /home/runner/k8s
+    volumes:
+      - name: work
+        ephemeral:
+          volumeClaimTemplate:
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: "csi-disk"
+              resources:
+                requests:
+                  storage: 32Gi
+      - name: pod-templates
+        configMap:
+          name: pod-template-npu-1
+      - name: shared-volume
+        persistentVolumeClaim:
+          claimName: nv-action-vllm-benchmarks-v2
+      - name: custom-index
+        persistentVolumeClaim:
+          claimName: custom-index
+      - name: app-data
+        emptyDir: {}
+

--- a/nv-action/vllm-benchmarks/linux-arm64-npu-2/Chart.lock
+++ b/nv-action/vllm-benchmarks/linux-arm64-npu-2/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gha-runner-scale-set
+  repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+  version: 0.10.1
+digest: sha256:6b60dc58ccdc6cb8c773464a60ace403fa54c6f235a40999f9e290671ccc3b2b
+generated: "2025-05-16T11:51:52.93433332+08:00"

--- a/nv-action/vllm-benchmarks/linux-arm64-npu-2/Chart.yaml
+++ b/nv-action/vllm-benchmarks/linux-arm64-npu-2/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: linux-arm64-npu-2
+version: 0.10.1
+dependencies:
+  - name: gha-runner-scale-set
+    version: 0.10.1
+    repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+
+

--- a/nv-action/vllm-benchmarks/linux-arm64-npu-2/values.yaml
+++ b/nv-action/vllm-benchmarks/linux-arm64-npu-2/values.yaml
@@ -1,0 +1,76 @@
+githubConfigUrl: https://github.com/nv-action/vllm-benchmarks
+
+githubConfigSecret: nv-action-vllm-benchmarks-secret
+
+template:
+  spec:
+    serviceAccountName: runner-service-account
+    initContainers:
+      - name: copy-origin-file
+        image: ghcr.io/actions/actions-runner:latest
+        command: ["sh", "-c", "cp -a /home/runner/k8s/. /app-data/  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: app-data
+          mountPath: /app-data
+      - name: copy-pvc-file
+        image: busybox
+        command: ["sh", "-c", "cp -f /shared-data/index.js /app-data/index.js  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: custom-index
+          mountPath: /shared-data  # PVC挂载路径
+        - name: app-data
+          mountPath: /app-data
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: ACTIONS_RUNNER_CONTAINER_HOOKS
+            value: /home/runner/k8s/index.js
+          - name: ACTIONS_RUNNER_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+            value: "false"
+          - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
+            value: /home/runner/pod-templates/default.yaml
+          - name: ACTIONS_RUNNER_USE_KUBE_SCHEDULER
+            value: "true"
+          - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+            value: "3600"
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: pod-templates
+            mountPath: /home/runner/pod-templates
+            readOnly: true
+          - name: shared-volume
+            mountPath: /root/.cache
+          - name: app-data
+            mountPath: /home/runner/k8s
+    volumes:
+      - name: work
+        ephemeral:
+          volumeClaimTemplate:
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: "csi-disk"
+              resources:
+                requests:
+                  storage: 64Gi
+      - name: pod-templates
+        configMap:
+          name: pod-template-npu-2
+      - name: shared-volume
+        persistentVolumeClaim:
+          claimName: nv-action-vllm-benchmarks-v2
+      - name: custom-index
+        persistentVolumeClaim:
+          claimName: custom-index
+      - name: app-data
+        emptyDir: {}

--- a/nv-action/vllm-benchmarks/linux-arm64-npu-4/Chart.lock
+++ b/nv-action/vllm-benchmarks/linux-arm64-npu-4/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gha-runner-scale-set
+  repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+  version: 0.10.1
+digest: sha256:6b60dc58ccdc6cb8c773464a60ace403fa54c6f235a40999f9e290671ccc3b2b
+generated: "2025-05-16T11:53:08.752199459+08:00"

--- a/nv-action/vllm-benchmarks/linux-arm64-npu-4/Chart.yaml
+++ b/nv-action/vllm-benchmarks/linux-arm64-npu-4/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: linux-arm64-npu-4
+version: 0.10.1
+dependencies:
+  - name: gha-runner-scale-set
+    version: 0.10.1
+    repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+
+

--- a/nv-action/vllm-benchmarks/linux-arm64-npu-4/values.yaml
+++ b/nv-action/vllm-benchmarks/linux-arm64-npu-4/values.yaml
@@ -1,0 +1,78 @@
+githubConfigUrl: https://github.com/nv-action/vllm-benchmarks
+
+githubConfigSecret: nv-action-vllm-benchmarks-secret
+
+template:
+  spec:
+    serviceAccountName: runner-service-account
+    initContainers:
+      - name: copy-origin-file
+        image: ghcr.io/actions/actions-runner:latest
+        command: ["sh", "-c", "cp -a /home/runner/k8s/. /app-data/  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: app-data
+          mountPath: /app-data
+      - name: copy-pvc-file
+        image: busybox
+        command: ["sh", "-c", "cp -f /shared-data/index.js /app-data/index.js  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: custom-index
+          mountPath: /shared-data  # PVC挂载路径
+        - name: app-data
+          mountPath: /app-data
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: ACTIONS_RUNNER_CONTAINER_HOOKS
+            value: /home/runner/k8s/index.js
+          - name: ACTIONS_RUNNER_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+            value: "false"
+          - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
+            value: /home/runner/pod-templates/default.yaml
+          - name: ACTIONS_RUNNER_USE_KUBE_SCHEDULER
+            value: "true"
+          - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+            value: "3600"
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: pod-templates
+            mountPath: /home/runner/pod-templates
+            readOnly: true
+          - name: shared-volume
+            mountPath: /root/.cache
+          - name: app-data
+            mountPath: /home/runner/k8s
+    volumes:
+      - name: work
+        ephemeral:
+          volumeClaimTemplate:
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: "csi-disk"
+              resources:
+                requests:
+                  storage: 64Gi
+      - name: pod-templates
+        configMap:
+          name: pod-template-npu-4
+      - name: shared-volume
+        persistentVolumeClaim:
+          claimName: nv-action-vllm-benchmarks-v2
+      - name: custom-index
+        persistentVolumeClaim:
+          claimName: custom-index
+      - name: app-data
+        emptyDir: {}
+
+

--- a/nv-action/vllm-benchmarks/linux-arm64-npu-8/Chart.lock
+++ b/nv-action/vllm-benchmarks/linux-arm64-npu-8/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gha-runner-scale-set
+  repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+  version: 0.10.1
+digest: sha256:6b60dc58ccdc6cb8c773464a60ace403fa54c6f235a40999f9e290671ccc3b2b
+generated: "2025-05-16T11:53:27.331504289+08:00"

--- a/nv-action/vllm-benchmarks/linux-arm64-npu-8/Chart.yaml
+++ b/nv-action/vllm-benchmarks/linux-arm64-npu-8/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: linux-arm64-npu-8
+version: 0.10.1
+dependencies:
+  - name: gha-runner-scale-set
+    version: 0.10.1
+    repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+
+

--- a/nv-action/vllm-benchmarks/linux-arm64-npu-8/values.yaml
+++ b/nv-action/vllm-benchmarks/linux-arm64-npu-8/values.yaml
@@ -1,0 +1,78 @@
+githubConfigUrl: https://github.com/nv-action/vllm-benchmarks
+
+githubConfigSecret: nv-action-vllm-benchmarks-secret
+
+template:
+  spec:
+    serviceAccountName: runner-service-account
+    initContainers:
+      - name: copy-origin-file
+        image: ghcr.io/actions/actions-runner:latest
+        command: ["sh", "-c", "cp -a /home/runner/k8s/. /app-data/  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: app-data
+          mountPath: /app-data
+      - name: copy-pvc-file
+        image: busybox
+        command: ["sh", "-c", "cp -f /shared-data/index.js /app-data/index.js  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: custom-index
+          mountPath: /shared-data  # PVC挂载路径
+        - name: app-data
+          mountPath: /app-data
+    containers:
+      - name: runner
+        image: ghcr.io/actions/actions-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: ACTIONS_RUNNER_CONTAINER_HOOKS
+            value: /home/runner/k8s/index.js
+          - name: ACTIONS_RUNNER_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+            value: "false"
+          - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
+            value: /home/runner/pod-templates/default.yaml
+          - name: ACTIONS_RUNNER_USE_KUBE_SCHEDULER
+            value: "true"
+          - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+            value: "3600"
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: pod-templates
+            mountPath: /home/runner/pod-templates
+            readOnly: true
+          - name: shared-volume
+            mountPath: /root/.cache
+          - name: app-data
+            mountPath: /home/runner/k8s
+    volumes:
+      - name: work
+        ephemeral:
+          volumeClaimTemplate:
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: "csi-disk"
+              resources:
+                requests:
+                  storage: 64Gi
+      - name: pod-templates
+        configMap:
+          name: pod-template-npu-8
+      - name: shared-volume
+        persistentVolumeClaim:
+          claimName: nv-action-vllm-benchmarks-v2
+      - name: custom-index
+        persistentVolumeClaim:
+          claimName: custom-index
+      - name: app-data
+        emptyDir: {}
+
+

--- a/script.sh
+++ b/script.sh
@@ -1,0 +1,31 @@
+# 输入参数
+ORGANIZATION="custom-org3"
+REPOSITORY="repo1"
+INSTALLATION_NAME="linux-arm64-npu-2"
+
+
+NAMESPACE=${ORGANIZATION}
+
+# 创建namespace
+if ! kubectl get namespace "$NAMESPACE" &>/dev/null; then
+    kubectl create namespace "$NAMESPACE"
+fi
+
+# 部署或者更新pvc, configmap
+helm upgrade --install "${INSTALLATION_NAME}-config" -n "${NAMESPACE}" \
+    ./${ORGANIZATION}/${REPOSITORY}/${INSTALLATION_NAME}/arc-config \
+    -f ./${ORGANIZATION}/${REPOSITORY}/${INSTALLATION_NAME}/values.yaml
+
+
+# 生成 runner-scale-set values.yaml
+helm template \
+   ./${ORGANIZATION}/${REPOSITORY}/${INSTALLATION_NAME}/arc \
+    -f ./${ORGANIZATION}/${REPOSITORY}/${INSTALLATION_NAME}/values.yaml \
+    --show-only templates/runner-scale-set-values.yaml.gotemp > ./runner-scale-set-values.yaml
+
+# 部署 arc
+helm upgrade --install "${INSTALLATION_NAME}" -n "${NAMESPACE}"\
+    -f ./runner-scale-set-values.yaml \
+    oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts/gha-runner-scale-set --version=0.10.1
+
+

--- a/vllm-project/vllm-ascend/config/container-job-pod-template-npu-1-configmap.yaml
+++ b/vllm-project/vllm-ascend/config/container-job-pod-template-npu-1-configmap.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pod-template-npu-1
+  namespace: vllm-project
+data:
+  default.yaml: |
+    ---
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      annotations:
+        annotated-by: "extension"
+      labels:
+        labeled-by: "extension"
+    spec:
+      containers:
+        - name: $job
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: "23"
+              huawei.com/ascend-1980: "1"
+              memory: 64Gi
+            requests:
+              cpu: "23"
+              huawei.com/ascend-1980: "1"
+              memory: 32Gi
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /root/.cache
+            - name: driver-tools
+              mountPath: /usr/local/Ascend/driver/tools
+              readOnly: true
+            - name: check-npu
+              mountPath: /check-npu
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    # 配置github代理
+                    cat <<EOF >> /root/.gitconfig
+                    [url "https://gh-proxy.test.osinfra.cn/https://github.com/"]
+                        insteadOf = https://github.com/
+                    EOF
+      volumes:
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: nv-action-vllm-benchmarks-v2
+        - name: driver-tools
+          hostPath:
+            path: /usr/local/Ascend/driver/tools
+            type: Directory
+        - name: check-npu
+          configMap:
+            name: check-npu

--- a/vllm-project/vllm-ascend/config/container-job-pod-template-npu-2-configmap.yaml
+++ b/vllm-project/vllm-ascend/config/container-job-pod-template-npu-2-configmap.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pod-template-npu-2
+  namespace: vllm-project
+data:
+  default.yaml: |
+    ---
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      annotations:
+        annotated-by: "extension"
+      labels:
+        labeled-by: "extension"
+    spec:
+      containers:
+        - name: $job
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: "46"
+              huawei.com/ascend-1980: "2"
+              memory: 128Gi
+            requests:
+              cpu: "46"
+              huawei.com/ascend-1980: "2"
+              memory: 64Gi
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /root/.cache
+            - name: driver-tools
+              mountPath: /usr/local/Ascend/driver/tools
+              readOnly: true
+            - name: check-npu
+              mountPath: /check-npu
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    # 配置github代理
+                    cat <<EOF >> /root/.gitconfig
+                    [url "https://gh-proxy.test.osinfra.cn/https://github.com/"]
+                        insteadOf = https://github.com/
+                    EOF
+      volumes:
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: nv-action-vllm-benchmarks-v2
+        - name: driver-tools
+          hostPath:
+            path: /usr/local/Ascend/driver/tools
+        - name: check-npu
+          configMap:
+            name: check-npu

--- a/vllm-project/vllm-ascend/config/container-job-pod-template-npu-4-configmap.yaml
+++ b/vllm-project/vllm-ascend/config/container-job-pod-template-npu-4-configmap.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pod-template-npu-4
+  namespace: vllm-project
+data:
+  default.yaml: |
+    ---
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      annotations:
+        annotated-by: "extension"
+      labels:
+        labeled-by: "extension"
+    spec:
+      containers:
+        - name: $job
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: "92"
+              huawei.com/ascend-1980: "4"
+              memory: 256Gi
+            requests:
+              cpu: "92"
+              huawei.com/ascend-1980: "4"
+              memory: 128Gi
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /root/.cache
+            - name: driver-tools
+              mountPath: /usr/local/Ascend/driver/tools
+              readOnly: true
+            - name: check-npu
+              mountPath: /check-npu
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    # 配置github代理
+                    cat <<EOF >> /root/.gitconfig
+                    [url "https://gh-proxy.test.osinfra.cn/https://github.com/"]
+                        insteadOf = https://github.com/
+                    EOF
+      volumes:
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: nv-action-vllm-benchmarks-v2
+        - name: driver-tools
+          hostPath:
+            path: /usr/local/Ascend/driver/tools
+        - name: check-npu
+          configMap:
+            name: check-npu
+

--- a/vllm-project/vllm-ascend/config/container-job-pod-template-npu-8-configmap.yaml
+++ b/vllm-project/vllm-ascend/config/container-job-pod-template-npu-8-configmap.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pod-template-npu-8
+  namespace: vllm-project
+data:
+  default.yaml: |
+    ---
+    apiVersion: v1
+    kind: PodTemplate
+    metadata:
+      annotations:
+        annotated-by: "extension"
+      labels:
+        labeled-by: "extension"
+    spec:
+      containers:
+        - name: $job
+          imagePullPolicy: Always
+          resources:
+            limits:
+              cpu: "184"
+              huawei.com/ascend-1980: "8"
+              memory: 512Gi
+            requests:
+              cpu: "184"
+              huawei.com/ascend-1980: "8"
+              memory: 256Gi
+          volumeMounts:
+            - name: shared-volume
+              mountPath: /root/.cache
+            - name: driver-tools
+              mountPath: /usr/local/Ascend/driver/tools
+              readOnly: true
+            - name: check-npu
+              mountPath: /check-npu
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    # 配置github代理
+                    cat <<EOF >> /root/.gitconfig
+                    [url "https://gh-proxy.test.osinfra.cn/https://github.com/"]
+                        insteadOf = https://github.com/
+                    EOF
+      volumes:
+        - name: shared-volume
+          persistentVolumeClaim:
+            claimName: nv-action-vllm-benchmarks-v2
+        - name: driver-tools
+          hostPath:
+            path: /usr/local/Ascend/driver/tools
+        - name: check-npu
+          configMap:
+            name: check-npu
+

--- a/vllm-project/vllm-ascend/config/custom-runner-container-hook-pvc.yaml
+++ b/vllm-project/vllm-ascend/config/custom-runner-container-hook-pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    everest.io/path: /custom-index
+    everest.io/reclaim-policy: retain-volume-only
+    everest.io/sfsturbo-share-id: 39a33a00-3be8-4345-8079-63cf23a44a88
+    everest.io/volume-as: absolute-path变
+    pvc-can-cleanup: 'true'
+  name: custom-index
+  namespace: vllm-project
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 50Mi
+  storageClassName: csi-sfsturbo

--- a/vllm-project/vllm-ascend/config/kustomization.yaml
+++ b/vllm-project/vllm-ascend/config/kustomization.yaml
@@ -1,0 +1,19 @@
+resources:
+- namespace.yaml
+- custom-runner-container-hook-pvc.yaml
+- local-storage-pvc.yaml
+- pre-execute-script-check-npu-configmap.yaml
+- runner-pod-permission.yaml
+- container-job-pod-template-npu-1-configmap.yaml
+- container-job-pod-template-npu-2-configmap.yaml
+- container-job-pod-template-npu-4-configmap.yaml
+- container-job-pod-template-npu-8-configmap.yaml
+namespace: vllm-project
+apiVersion: kustomize.config.k8s.io/v1beta1
+commonAnnotations:
+  kubernetes.ops.cluster: shanghai-icsl-cluster
+  kubernetes.ops.email: ""
+  kubernetes.ops.os.base: debian
+  kubernetes.ops.region: shanghai
+kind: Kustomization
+

--- a/vllm-project/vllm-ascend/config/local-storage-pvc.yaml
+++ b/vllm-project/vllm-ascend/config/local-storage-pvc.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  annotations:
+    everest.io/path: /ascend-ci-share-nv-action-vllm-benchmarks
+    everest.io/reclaim-policy: retain-volume-only
+    everest.io/sfsturbo-share-id: 23021270-7ebf-43b2-925c-b1686da4868a
+    everest.io/volume-as: absolute-path
+    pvc-can-cleanup: 'true'
+  name: nv-action-vllm-benchmarks-v2
+  namespace: vllm-project
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 1200Gi
+  storageClassName: csi-sfsturbo

--- a/vllm-project/vllm-ascend/config/namespace.yaml
+++ b/vllm-project/vllm-ascend/config/namespace.yaml
@@ -1,0 +1,7 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    app: vllm-project
+  name: vllm-project

--- a/vllm-project/vllm-ascend/config/pre-execute-script-check-npu-configmap.yaml
+++ b/vllm-project/vllm-ascend/config/pre-execute-script-check-npu-configmap.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: check-npu
+  namespace: vllm-project
+data:
+  check.sh: |
+    #!/bin/bash
+    if [ -c "/dev/davinci_manager" ]; then
+        while true; do
+            if npu-smi info &> /dev/null ; then
+                break
+            fi
+            sleep 1
+        done
+    fi

--- a/vllm-project/vllm-ascend/config/runner-pod-permission.yaml
+++ b/vllm-project/vllm-ascend/config/runner-pod-permission.yaml
@@ -1,0 +1,48 @@
+---
+# Source: gha-runner-scale-set/templates/kube_mode_serviceaccount.yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: runner-service-account
+  namespace: vllm-project
+
+---
+# Source: gha-runner-scale-set/templates/kube_mode_role.yaml
+# default permission for runner pod service account in kubernetes mode (container hook)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: runner-role
+  namespace: vllm-project
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["get", "create"]
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["batch"]
+    resources: ["jobs"]
+    verbs: ["get", "list", "create", "delete"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "create", "delete"]
+---
+# Source: gha-runner-scale-set/templates/kube_mode_role_binding.yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: runner-rolebinding
+  namespace: vllm-project
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: runner-role
+subjects:
+  - kind: ServiceAccount
+    name: runner-service-account
+    namespace: vllm-project
+---

--- a/vllm-project/vllm-ascend/linux-arm64-npu-1/Chart.lock
+++ b/vllm-project/vllm-ascend/linux-arm64-npu-1/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gha-runner-scale-set
+  repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+  version: 0.10.1
+digest: sha256:6b60dc58ccdc6cb8c773464a60ace403fa54c6f235a40999f9e290671ccc3b2b
+generated: "2025-05-16T11:42:14.31053914+08:00"

--- a/vllm-project/vllm-ascend/linux-arm64-npu-1/Chart.yaml
+++ b/vllm-project/vllm-ascend/linux-arm64-npu-1/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: linux-arm64-npu-1
+version: 0.10.1
+dependencies:
+  - name: gha-runner-scale-set
+    version: 0.10.1
+    repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+
+

--- a/vllm-project/vllm-ascend/linux-arm64-npu-1/values.yaml
+++ b/vllm-project/vllm-ascend/linux-arm64-npu-1/values.yaml
@@ -1,0 +1,77 @@
+githubConfigUrl: https://github.com/vllm-project/vllm-ascend
+
+githubConfigSecret: vllm-project-vllm-ascend-secret
+
+template:
+  spec:
+    serviceAccountName: runner-service-account
+    initContainers:
+      - name: copy-origin-file
+        image: ghcr.nju.edu.cn/actions/actions-runner:latest
+        command: ["sh", "-c", "cp -a /home/runner/k8s/. /app-data/  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: app-data
+          mountPath: /app-data
+      - name: copy-pvc-file
+        image: busybox
+        command: ["sh", "-c", "cp -f /shared-data/index.js /app-data/index.js  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: custom-index
+          mountPath: /shared-data
+        - name: app-data
+          mountPath: /app-data
+    containers:
+      - name: runner
+        image: ghcr.nju.edu.cn/actions/actions-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: ACTIONS_RUNNER_CONTAINER_HOOKS
+            value: /home/runner/k8s/index.js
+          - name: ACTIONS_RUNNER_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+            value: "false"
+          - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
+            value: /home/runner/pod-templates/default.yaml
+          - name: ACTIONS_RUNNER_USE_KUBE_SCHEDULER
+            value: "true"
+          - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+            value: "3600"
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: pod-templates
+            mountPath: /home/runner/pod-templates
+            readOnly: true
+          - name: shared-volume
+            mountPath: /root/.cache
+          - name: app-data
+            mountPath: /home/runner/k8s
+    volumes:
+      - name: work
+        ephemeral:
+          volumeClaimTemplate:
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: "csi-disk"
+              resources:
+                requests:
+                  storage: 32Gi
+      - name: pod-templates
+        configMap:
+          name: pod-template-npu-1
+      - name: shared-volume
+        persistentVolumeClaim:
+          claimName: nv-action-vllm-benchmarks-v2
+      - name: custom-index
+        persistentVolumeClaim:
+          claimName: custom-index
+      - name: app-data
+        emptyDir: {}
+

--- a/vllm-project/vllm-ascend/linux-arm64-npu-2/Chart.lock
+++ b/vllm-project/vllm-ascend/linux-arm64-npu-2/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gha-runner-scale-set
+  repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+  version: 0.10.1
+digest: sha256:6b60dc58ccdc6cb8c773464a60ace403fa54c6f235a40999f9e290671ccc3b2b
+generated: "2025-05-16T11:45:23.877987663+08:00"

--- a/vllm-project/vllm-ascend/linux-arm64-npu-2/Chart.yaml
+++ b/vllm-project/vllm-ascend/linux-arm64-npu-2/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: linux-arm64-npu-2
+version: 0.10.1
+dependencies:
+  - name: gha-runner-scale-set
+    version: 0.10.1
+    repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+
+

--- a/vllm-project/vllm-ascend/linux-arm64-npu-2/values.yaml
+++ b/vllm-project/vllm-ascend/linux-arm64-npu-2/values.yaml
@@ -1,0 +1,76 @@
+githubConfigUrl: https://github.com/vllm-project/vllm-ascend
+
+githubConfigSecret: vllm-project-vllm-ascend-secret
+
+template:
+  spec:
+    serviceAccountName: runner-service-account
+    initContainers:
+      - name: copy-origin-file
+        image: ghcr.nju.edu.cn/actions/actions-runner:latest
+        command: ["sh", "-c", "cp -a /home/runner/k8s/. /app-data/  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: app-data
+          mountPath: /app-data
+      - name: copy-pvc-file
+        image: busybox
+        command: ["sh", "-c", "cp -f /shared-data/index.js /app-data/index.js  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: custom-index
+          mountPath: /shared-data  # PVC挂载路径
+        - name: app-data
+          mountPath: /app-data
+    containers:
+      - name: runner
+        image: ghcr.nju.edu.cn/actions/actions-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: ACTIONS_RUNNER_CONTAINER_HOOKS
+            value: /home/runner/k8s/index.js
+          - name: ACTIONS_RUNNER_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+            value: "false"
+          - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
+            value: /home/runner/pod-templates/default.yaml
+          - name: ACTIONS_RUNNER_USE_KUBE_SCHEDULER
+            value: "true"
+          - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+            value: "3600"
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: pod-templates
+            mountPath: /home/runner/pod-templates
+            readOnly: true
+          - name: shared-volume
+            mountPath: /root/.cache
+          - name: app-data
+            mountPath: /home/runner/k8s
+    volumes:
+      - name: work
+        ephemeral:
+          volumeClaimTemplate:
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: "csi-disk"
+              resources:
+                requests:
+                  storage: 64Gi
+      - name: pod-templates
+        configMap:
+          name: pod-template-npu-2
+      - name: shared-volume
+        persistentVolumeClaim:
+          claimName: nv-action-vllm-benchmarks-v2
+      - name: custom-index
+        persistentVolumeClaim:
+          claimName: custom-index
+      - name: app-data
+        emptyDir: {}

--- a/vllm-project/vllm-ascend/linux-arm64-npu-4/Chart.lock
+++ b/vllm-project/vllm-ascend/linux-arm64-npu-4/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gha-runner-scale-set
+  repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+  version: 0.10.1
+digest: sha256:6b60dc58ccdc6cb8c773464a60ace403fa54c6f235a40999f9e290671ccc3b2b
+generated: "2025-05-16T11:46:13.038990416+08:00"

--- a/vllm-project/vllm-ascend/linux-arm64-npu-4/Chart.yaml
+++ b/vllm-project/vllm-ascend/linux-arm64-npu-4/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: linux-arm64-npu-4
+version: 0.10.1
+dependencies:
+  - name: gha-runner-scale-set
+    version: 0.10.1
+    repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+
+

--- a/vllm-project/vllm-ascend/linux-arm64-npu-4/values.yaml
+++ b/vllm-project/vllm-ascend/linux-arm64-npu-4/values.yaml
@@ -1,0 +1,76 @@
+githubConfigUrl: https://github.com/vllm-project/vllm-ascend
+
+githubConfigSecret: vllm-project-vllm-ascend-secret
+
+template:
+  spec:
+    serviceAccountName: runner-service-account
+    initContainers:
+      - name: copy-origin-file
+        image: ghcr.nju.edu.cn/actions/actions-runner:latest
+        command: ["sh", "-c", "cp -a /home/runner/k8s/. /app-data/  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: app-data
+          mountPath: /app-data
+      - name: copy-pvc-file
+        image: busybox
+        command: ["sh", "-c", "cp -f /shared-data/index.js /app-data/index.js  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: custom-index
+          mountPath: /shared-data  # PVC挂载路径
+        - name: app-data
+          mountPath: /app-data
+    containers:
+      - name: runner
+        image: ghcr.nju.edu.cn/actions/actions-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: ACTIONS_RUNNER_CONTAINER_HOOKS
+            value: /home/runner/k8s/index.js
+          - name: ACTIONS_RUNNER_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+            value: "false"
+          - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
+            value: /home/runner/pod-templates/default.yaml
+          - name: ACTIONS_RUNNER_USE_KUBE_SCHEDULER
+            value: "true"
+          - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+            value: "3600"
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: pod-templates
+            mountPath: /home/runner/pod-templates
+            readOnly: true
+          - name: shared-volume
+            mountPath: /root/.cache
+          - name: app-data
+            mountPath: /home/runner/k8s
+    volumes:
+      - name: work
+        ephemeral:
+          volumeClaimTemplate:
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: "csi-disk"
+              resources:
+                requests:
+                  storage: 64Gi
+      - name: pod-templates
+        configMap:
+          name: pod-template-npu-4
+      - name: shared-volume
+        persistentVolumeClaim:
+          claimName: nv-action-vllm-benchmarks-v2
+      - name: custom-index
+        persistentVolumeClaim:
+          claimName: custom-index
+      - name: app-data
+        emptyDir: {}

--- a/vllm-project/vllm-ascend/linux-arm64-npu-8/Chart.lock
+++ b/vllm-project/vllm-ascend/linux-arm64-npu-8/Chart.lock
@@ -1,0 +1,6 @@
+dependencies:
+- name: gha-runner-scale-set
+  repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+  version: 0.10.1
+digest: sha256:6b60dc58ccdc6cb8c773464a60ace403fa54c6f235a40999f9e290671ccc3b2b
+generated: "2025-05-16T11:49:10.806702207+08:00"

--- a/vllm-project/vllm-ascend/linux-arm64-npu-8/Chart.yaml
+++ b/vllm-project/vllm-ascend/linux-arm64-npu-8/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: linux-arm64-npu-8
+version: 0.10.1
+dependencies:
+  - name: gha-runner-scale-set
+    version: 0.10.1
+    repository: oci://ghcr.nju.edu.cn/actions/actions-runner-controller-charts
+
+

--- a/vllm-project/vllm-ascend/linux-arm64-npu-8/values.yaml
+++ b/vllm-project/vllm-ascend/linux-arm64-npu-8/values.yaml
@@ -1,0 +1,76 @@
+githubConfigUrl: https://github.com/vllm-project/vllm-ascend
+
+githubConfigSecret: vllm-project-vllm-ascend-secret
+
+template:
+  spec:
+    serviceAccountName: runner-service-account
+    initContainers:
+      - name: copy-origin-file
+        image: ghcr.nju.edu.cn/actions/actions-runner:latest
+        command: ["sh", "-c", "cp -a /home/runner/k8s/. /app-data/  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: app-data
+          mountPath: /app-data
+      - name: copy-pvc-file
+        image: busybox
+        command: ["sh", "-c", "cp -f /shared-data/index.js /app-data/index.js  && chown -R 1001:1001 /app-data"]
+        securityContext:
+          runAsUser: 0
+        volumeMounts:
+        - name: custom-index
+          mountPath: /shared-data  # PVC挂载路径
+        - name: app-data
+          mountPath: /app-data
+    containers:
+      - name: runner
+        image: ghcr.nju.edu.cn/actions/actions-runner:latest
+        command: ["/home/runner/run.sh"]
+        env:
+          - name: ACTIONS_RUNNER_CONTAINER_HOOKS
+            value: /home/runner/k8s/index.js
+          - name: ACTIONS_RUNNER_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: ACTIONS_RUNNER_REQUIRE_JOB_CONTAINER
+            value: "false"
+          - name: ACTIONS_RUNNER_CONTAINER_HOOK_TEMPLATE
+            value: /home/runner/pod-templates/default.yaml
+          - name: ACTIONS_RUNNER_USE_KUBE_SCHEDULER
+            value: "true"
+          - name: ACTIONS_RUNNER_PREPARE_JOB_TIMEOUT_SECONDS
+            value: "3600"
+        volumeMounts:
+          - name: work
+            mountPath: /home/runner/_work
+          - name: pod-templates
+            mountPath: /home/runner/pod-templates
+            readOnly: true
+          - name: shared-volume
+            mountPath: /root/.cache
+          - name: app-data
+            mountPath: /home/runner/k8s
+    volumes:
+      - name: work
+        ephemeral:
+          volumeClaimTemplate:
+            spec:
+              accessModes: ["ReadWriteOnce"]
+              storageClassName: "csi-disk"
+              resources:
+                requests:
+                  storage: 64Gi
+      - name: pod-templates
+        configMap:
+          name: pod-template-npu-8
+      - name: shared-volume
+        persistentVolumeClaim:
+          claimName: nv-action-vllm-benchmarks-v2
+      - name: custom-index
+        persistentVolumeClaim:
+          claimName: custom-index
+      - name: app-data
+        emptyDir: {}


### PR DESCRIPTION
完整目录在[这里](https://github.com/opensourceways/ascend-ci-deployment/tree/feature/sample)

以`custom-org3/repo1/linux-arm64-npu-2/`为例
`custom-org3`是组织名称
`repo1`是仓库名称
`linux-arm64-npu-2`是runner set名称。`npu-1`代表1卡Runner，`npu-2`代表2卡Runner，`npu-4`代表4卡Runner。

---
为仓库安装`Runner set`之前，需要按照[文档](https://docs.github.com/en/enterprise-server@3.10/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/quickstart-for-actions-runner-controller#installing-actions-runner-controller)安装`ARC controller`。

---
[脚本](https://github.com/opensourceways/ascend-ci-deployment/blob/feature/sample/script.sh)分三步为`custom-org3/repo1`仓库配置`linux-arm64-npu-2``Runner set`。

第一步：执行[Runner set config chart](custom-org3/repo1/linux-arm64-npu-2/arc-config/templates)，安装`Runner set`相关configmap和pvc。
每个`Runner set`对应的[values.yaml](https://github.com/opensourceways/ascend-ci-deployment/blob/feature/sample/custom-org3/repo1/linux-arm64-npu-2/values.yaml)都不同，并且`customIndexPvcId, localStoragePvcId, pat`以secret保存。

|文件名|含义|
|--|--|
|local-storage-pvc.yaml|`ReadWriteMany`跨节点缓存|
|custom-runner-container-hook-pvc.yaml|存储[自定义runner-container-hook](https://github.com/cllouud/runner-container-hooks/releases/tag/v0.1.2), `runner pod`调用`runner-container-hook`实现：在同namespace下创建`container job pod`并且执行workflow命令|
|container-job-pod-template-npu-1-configmap.yaml|[`container job pod`的模板](https://docs.github.com/en/enterprise-server@3.10/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/deploying-runner-scale-sets-with-actions-runner-controller#configuring-hook-extensions)，在模板里挂载NPU卡|
|pre-execute-script-check-npu-configmap.yaml|由于[Bug: the device is used 8020](https://github.com/ascend-gha-runners/docs/issues/11)，配置的预检查`npu-smi info`脚本|
|runner-scale-set-values.yaml|通过[helm chart](https://docs.github.com/en/enterprise-server@3.10/actions/hosting-your-own-runners/managing-self-hosted-runners-with-actions-runner-controller/deploying-runner-scale-sets-with-actions-runner-controller#deploying-a-runner-scale-set)安装`runner set`的`values.yaml`文件|
|runner-pod-permission.yaml|定义`runner pod`的[权限](https://github.com/actions/runner-container-hooks/blob/main/packages/k8s/README.md)，使其能够创建`container job pod`|

第二步：执行[Runner set chart](https://github.com/opensourceways/ascend-ci-deployment/tree/feature/sample/custom-org3/repo1/linux-arm64-npu-2/arc/templates)生成生成`Runner set` 的`values.yaml`。

第三步：安装runner  scale  set。




